### PR TITLE
Fixing the "continue ;" bug

### DIFF
--- a/blinux-make/norme_deepthought.py
+++ b/blinux-make/norme_deepthought.py
@@ -352,6 +352,8 @@ class norme:
         ret = self.line.find("return")
         if ret == -1:
             ret = self.line.find("break")
+        if ret == -1:
+            ret = self.line.find("continue")
         par = self.line.find("(")
         if (ret != -1 and par == -1):
             pos = pos + 1


### PR DESCRIPTION
"continue ;" is currently counted as a norme mistake and shouldn't.
Fixed by adding the same method used for "break" and "return".